### PR TITLE
Change shebang to point to python2

### DIFF
--- a/xbev.py
+++ b/xbev.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #
 # xbev

--- a/xbmcclient.py
+++ b/xbmcclient.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
+
 # -*- coding: utf-8 -*-
 
 #   Copyright (C) 2008-2009 Team XBMC http://www.xbmc.org

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
+
 # -*- coding: utf-8 -*-
 
 #   Copyright (C) 2008-2009 Team XBMC http://www.xbmc.org


### PR DESCRIPTION
I'd assume that `/usr/bin/python` will gradually change from pointing to Python 2 to Python 3 while Python 3 will become more widespread.

`/usr/bin/python2` on the other hand is avialable on most systems to enable legacy Python 2 scripts to still run. Xbev is incompatible with Python 3, so I would suggest changing the shebang to point to Python 2.
